### PR TITLE
Move definition to try to fix conflict.

### DIFF
--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -138,6 +138,10 @@ extern layer_state_t layer_state;
 #    include "process_magic.h"
 #endif
 
+#ifdef JOYSTICK_ENABLE
+#    include "joystick.h"
+#endif
+
 #if defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
 #    include "process_rgb.h"
 #endif
@@ -160,10 +164,6 @@ extern layer_state_t layer_state;
 
 #ifdef DYNAMIC_MACRO_ENABLE
 #    include "process_dynamic_macro.h"
-#endif
-
-#ifdef JOYSTICK_ENABLE 
-#    include "joystick.h"
 #endif
 
 // Function substitutions to ease GPIO manipulation


### PR DESCRIPTION
Moved the include inside quantum.h to attempt to fix up the merge conflicts with the main PR into QMK actual.